### PR TITLE
Added minimal pyproject.toml for pip 25.3+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- Fixes update-nightly-env: http://spherexdev2.ipac.caltech.edu:8100/job/update-nightly-env/133/
- Not the direct cause of errors in other integration tests
  - spherex-nightly: http://spherexdev2.ipac.caltech.edu:8100/job/spherex-nightly/1099/
  - spherex-ingest-nightly: http://spherexdev2.ipac.caltech.edu:8100/job/spherex-ingest-nightly/886/
  